### PR TITLE
Added a custom ffmpeg location and the ability to remap media paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This Discord bot connects to a plex server and allows the streaming of movies to
 
 A couple of assumptions are made that may need to be changed to work on different systems and these are:
 - Your Plex movie Library is named  `Movies`
-- the ffmpeg process is located at `/root/bin/ffmpeg`
 - No other `ffmpeg` processes are running on the same system
 
 Theoretically all you need to do to get started as far as I know:
@@ -12,6 +11,7 @@ Theoretically all you need to do to get started as far as I know:
 - `pip3 install -r requirements.txt `
 - `python3 app.py`
 
+If the path to the media is different on the plex server compared to the stream server add remapped folders in the config in the format of
 
-## Example usage
-![Example usage](https://i.vangel.io/KZuaK.png)
+`PLEX_FOLDER:STREAM_FOLDER,`
+

--- a/app.py
+++ b/app.py
@@ -25,9 +25,14 @@ client = discord.Client()
 
 def startMovie(path, channel):
     devnull = open('/dev/null', 'w')
+
+    for x in config['plex']['RemappedFolders'].split(","):
+        oldPath, newPath = x.split(":")
+        path = path.replace(oldPath, newPath)
+
     # Start streaming the movie using ffmpeg
     # Path to movie is pulled from the plex api because the paths are the same on both machines
-    subprocess.call(["/root/bin/ffmpeg", "-re", "-i", path, "-c:v", "libx264", "-filter:v", "scale=1280:trunc(ow/a/2)*2", "-preset", "fast", "-minrate", "500k", "-maxrate", "3000k", "-bufsize", "6M", "-c:a", "libfdk_aac", "-b:a", "160k", "-f", "flv", config['stream']['Destination']], stdout=devnull)
+    subprocess.call([config['stream']['FFMPEGLocation'], "-re", "-i", path, "-c:v", "libx264", "-filter:v", "scale=1280:trunc(ow/a/2)*2", "-preset", "fast", "-minrate", "500k", "-maxrate", "3000k", "-bufsize", "6M", "-c:a", "libfdk_aac", "-b:a", "160k", "-f", "flv", config['stream']['Destination']], stdout=devnull)
     # Notifiy that the movie has finished
     client.send_message(channel, 'Stream has finished')
     # Set the movie playing variable to false to allow a new movie to be streamed

--- a/config.example.ini
+++ b/config.example.ini
@@ -2,7 +2,9 @@
 Username = 
 Password = 
 Server = 
+RemappedFolders = /data/media1:/plexmedia1,/data/media2:/plexmedia2
 [discord]
 Key = 
 [stream]
 Destination = 
+FFMPEGLocation = ffmpeg


### PR DESCRIPTION
Default ffmpeg location assumes ffmpeg is in the path
Remapped folders allow for different paths on the plex server and stream server